### PR TITLE
fix: registry API endpoint

### DIFF
--- a/docs/graphcast/radios/poi-radio.md
+++ b/docs/graphcast/radios/poi-radio.md
@@ -64,7 +64,7 @@ The POI Radio is configured using environment variables. You will need to prepar
 | ------------------------------------- | ---------------------------------------------------------------------------------------- |
 | `PRIVATE_KEY`                         | Private key for your Graphcast ID.<br/>Example: `0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`                       |
 | `GRAPH_NODE_STATUS_ENDPOINT`          | URL to a Graph Node Indexing Status endpoint.<br/>Example: `http://index-node:8030/graphql` |
-| `REGISTRY_SUBGRAPH`                   | URL to the Graphcast Registry subgraph for your network.<br/>Mainnet: `https://thegraph.com/hosted-service/subgraph/hopeyen/graphcast-registry-mainnet`<br/>Goerli: `https://thegraph.com/hosted-service/subgraph/hopeyen/graphcast-registry-goerli`        |
+| `REGISTRY_SUBGRAPH`                   | URL to the Graphcast Registry subgraph for your network.<br/>Mainnet: `https://api.thegraph.com/subgraphs/name/hopeyen/graphcast-registry-mainnet`<br/>Goerli: `https://api.thegraph.com/subgraphs/name/hopeyen/graphcast-registry-goerli`        |
 | `NETWORK_SUBGRAPH`                    | URL to the Graph Network subgraph<br/>Mainnet: `https://gateway.thegraph.com/network`<br/>Goerli: `https://gateway.testnet.thegraph.com/network`|
 | `GRAPHCAST_NETWORK`                   | The Graphcast Messaging fleet and pubsub namespace to use.<br/>Mainnet: `mainnet`<br/>Goerli: `testnet`|
 

--- a/docs/graphcast/sdk/radio-dev.md
+++ b/docs/graphcast/sdk/radio-dev.md
@@ -209,7 +209,7 @@ let radio_name: &str = "ping-pong";
 
 /// A constant defining the goerli registry subgraph endpoint.
 pub const REGISTRY_SUBGRAPH: &str =
-    "https://api.thegraph.com/subgraphs/name/hopeyen/gossip-registry-test";
+    "https://api.thegraph.com/subgraphs/name/hopeyen/gossip-registry-goerli";
 
 /// A constant defining the goerli network subgraph endpoint.
 pub const NETWORK_SUBGRAPH: &str = "https://gateway.testnet.thegraph.com/network";


### PR DESCRIPTION
quick fix to replace the hosted service website url to subgraph API endpoint